### PR TITLE
fix typo in README series orderby startYear, not startDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Descriptions and examples of the supported actions are below. Note, all methods 
 ```ruby
 @client.series
 @client.series(title: 'Uncanny X-Men')
-@client.series(titleStartsWith: 'Astonishing', orderBy: 'startDate', limit: 100)
+@client.series(titleStartsWith: 'Astonishing', orderBy: 'startYear', limit: 100)
 ```
 
 - Fetches a single comic series by id. [`GET /v1/public/series/{seriesId}`](http://developer.marvel.com/docs#!/public/getSeriesIndividual_get_26)

--- a/spec/marvel_api/client/client_series_spec.rb
+++ b/spec/marvel_api/client/client_series_spec.rb
@@ -19,6 +19,16 @@ describe Marvel::Client do
                   '15-Love GN-TPB (2013 - Present)']
       end
 
+      it 'can order list by startYear' do
+        sorted_list = client.series.sort_by {|entry| entry["startYear"]}
+        
+        sorted_start_years = sorted_list.map {|entry| entry["startYear"]}
+        unsorted_start_years = client.series.map {|entry| entry["startYear"]}
+
+        expect(sorted_start_years == unsorted_start_years).to eq(false)
+        expect(sorted_start_years == unsorted_start_years.sort).to eq(true)
+      end
+
       it 'requests public/v1/series successfully' do
         expect(client.series.status).to eq 'Ok'
       end


### PR DESCRIPTION
http://developer.marvel.com/docs#!/public/getSeriesCollection_get_25

GET /v1/public/series , Series uses "startYear" not "startDate" as the attribute.
